### PR TITLE
Documentation issue mundissec INE, by Team Raposos

### DIFF
--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -39,6 +39,7 @@ export default {
       open: true,
       pages: [
         {name: "Font i dades", path: "/dades/"},
+        {name: "Some issues", path: "/dades/issues"},
       ]
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/src/dades/issues.md
+++ b/src/dades/issues.md
@@ -1,12 +1,14 @@
-# Issue with `mundissec` Column in `certificats.csv`
+# Some issues
+
+## Issue with `mundissec` column in `certificats.csv`
 
 Brought to you by Team Raposos 🦊
 
-## Problem Description
+### Problem Description
 
 The `mundissec` column in `certificats.csv` represents the **unique identifier of the census section** where the building is located. In theory, this column should allow for a direct join with data from the **INE (Institut Nacional d'Estadística)**, using the census section identifier from both datasets. However, the codes **do not match**, preventing a straightforward merge.
 
-## Example of the Issue
+### Example of the Issue
 
 For example, in the municipality of **Abrera**:
 
@@ -21,11 +23,15 @@ For example, in the municipality of **Abrera**:
 
 This pattern appears across **all `mundissec` codes** in `certificats.csv`, making it impossible to directly join the datasets.
 
-## Proposed Solution
+### Proposed Solution
 
 The simplest way to fix this issue is to **remove the 6th character** from the `mundissec` column. This transformation will align the codes with those in the INE dataset.
 This issue should be **taken into account** when performing analyses requiring census section-level information.
 
+
+
+This section serves as a reference for anyone attempting to merge the datasets and ensures that the `mundissec` column is properly aligned with official census codes.
+
 ---
 
-This document serves as a reference for anyone attempting to merge the datasets and ensures that the `mundissec` column is properly aligned with official census codes.
+<!-- Add further issues if needed following a similar format starting with "## Issue..." -->

--- a/src/dades/join-ine.md
+++ b/src/dades/join-ine.md
@@ -1,6 +1,6 @@
 # Issue with `mundissec` Column in `certificats.csv`
 
-Brought to you by Team Raposos
+Brought to you by Team Raposos 🦊
 
 ## Problem Description
 

--- a/src/dades/join-ine.md
+++ b/src/dades/join-ine.md
@@ -1,0 +1,31 @@
+# Issue with `mundissec` Column in `certificats.csv`
+
+Brought to you by Team Raposos
+
+## Problem Description
+
+The `mundissec` column in `certificats.csv` represents the **unique identifier of the census section** where the building is located. In theory, this column should allow for a direct join with data from the **INE (Institut Nacional d'Estadística)**, using the census section identifier from both datasets. However, the codes **do not match**, preventing a straightforward merge.
+
+## Example of the Issue
+
+For example, in the municipality of **Abrera**:
+
+- An example of a unique identifier of the census section from **INE** is:  
+  **`0800101001`**  
+  - `08001` → Municipal code  
+  - `01001` → Section code  
+
+- However, in **certificats.csv**, the `mundissec` value appears as:  
+  **`08001801001`**  
+  - Notice the **extra "8"** inserted between the municipal code and the section code.
+
+This pattern appears across **all `mundissec` codes** in `certificats.csv`, making it impossible to directly join the datasets.
+
+## Proposed Solution
+
+The simplest way to fix this issue is to **remove the 6th character** from the `mundissec` column. This transformation will align the codes with those in the INE dataset.
+This issue should be **taken into account** when performing analyses requiring census section-level information.
+
+---
+
+This document serves as a reference for anyone attempting to merge the datasets and ensures that the `mundissec` column is properly aligned with official census codes.


### PR DESCRIPTION
Added documentation explaining the issue where the section code from INE data and the unique identifier of the census section from certificats.csv does not match, preventing straightforward merging.